### PR TITLE
Update to work with python3 as well, and less ressources

### DIFF
--- a/musnify-mpd.py
+++ b/musnify-mpd.py
@@ -28,11 +28,11 @@ if not os.path.isfile(configFile):
 config = ConfigParser()
 config.read(configFile)
 
-host = config.get("mpd","host")
-port = config.get("mpd","port")
+host = config.get("mpd","host", fallback=os.environ.get("MPD_HOST", "localhost"))
+port = config.get("mpd","port", fallback=os.environ.get("MPD_PORT", 6600))
 if config.has_option("apiKey", "lastfm"):
     apiKey = config.get("apiKey", "lastfm")
-musicLibrary = os.path.expanduser(config.get("mpd","musiclibrary")) + "/"
+musicLibrary = os.path.expanduser(config.get("mpd","musiclibrary", fallback='~/Music')) + "/"
 
 debug = False
 

--- a/musnify-mpd.py
+++ b/musnify-mpd.py
@@ -1,5 +1,8 @@
 # coding: utf-8
-import ConfigParser
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 import json
 import os
 import sys
@@ -22,7 +25,7 @@ if not os.path.isfile(configFile):
     print("Loading default config")
     configFile = "/etc/musnify-mpd.config"
 
-config = ConfigParser.ConfigParser()
+config = ConfigParser()
 config.read(configFile)
 
 host = config.get("mpd","host")

--- a/musnify-mpd.py
+++ b/musnify-mpd.py
@@ -134,11 +134,14 @@ class CoverArt:
     @staticmethod
     def fetchLocalCover(path):
         regex = re.compile(r'(album|cover|\.?folder|front).*\.(gif|jpeg|jpg|png)$', re.I | re.X)
-        for e in os.listdir(path):
-            if regex.match(e) != None:
-                if debug:
-                    print("local cover found at " + path + e)
-                return Pixbuf.new_from_file(path + e)
+        try:
+            for e in os.listdir(path):
+                if regex.match(e) != None:
+                    if debug:
+                        print("local cover found at " + path + e)
+                    return Pixbuf.new_from_file(path + e)
+        except:
+            pass
         if debug:
             print("Nothing found on local directory")
         return False
@@ -210,21 +213,23 @@ def help():
   -d\t\tRun with debug mode enabled
          """)
 
-for i in range(len(sys.argv)):
-    if sys.argv[i] == "-h":
-        host = sys.argv[i + 1]
-    if sys.argv[i] == "-p":
-        port = sys.argv[i + 1]
-    if sys.argv[i] == "-d":
-        debug = True
-    if sys.argv[i] == "--help":
-        help()
-        exit()
-
 if __name__ == "__main__":
+    for i in range(len(sys.argv)):
+        if sys.argv[i] == "-h":
+            host = sys.argv[i + 1]
+        if sys.argv[i] == "-p":
+            port = sys.argv[i + 1]
+        if sys.argv[i] == "-d":
+            debug = True
+        if sys.argv[i] == "--help":
+            help()
+            exit()
+    
     musnify = Musnify()
 
     try:
         musnify.start()
+    except KeyboardInterrupt:
+        pass
     finally:
         musnify.stop()

--- a/musnify-mpd.py
+++ b/musnify-mpd.py
@@ -68,6 +68,9 @@ class MPDWrapper:
 
     def getStatus(self):
         return self.client.status()["state"]
+    
+    def waitForChange(self):
+        return self.client.idle("player")
 
 
 class NotificationWrapper:
@@ -158,7 +161,6 @@ class Musnify(object):
         song = ""
 
         while True:
-            time.sleep(0.5)
             actualStatus = mpd.getStatus()
             actualSong = mpd.getCurrentSong()
 
@@ -176,6 +178,8 @@ class Musnify(object):
                 self.handle(song)
                 if debug:
                     print(song)
+            
+            mpd.waitForChange()
 
     def handle(self, song):
         localCoverPath = CoverArt.fetchLocalCover(musicLibrary + self._separa(song["file"]))


### PR DESCRIPTION
[Use more portable way to import configparser](https://github.com/felipemarinho97/musnify-mpd/commit/7e6e6d9cd466ca493d8beceaed93d145e4a17ff6)
[Move argument parsing, handle exceptions](https://github.com/felipemarinho97/musnify-mpd/commit/0583e7f16f87097730bd4b2b196451865675dd25)
[Wait for events instead of busy wait](https://github.com/felipemarinho97/musnify-mpd/commit/0af1c4eb28147d117222e8430b6116fc91aa31b3)
[Provide fallbacks for config file entries](https://github.com/felipemarinho97/musnify-mpd/commit/36927541d07e73b7013af7239db93716d01ae3f4)